### PR TITLE
Fix duplicate external files in Node.js archive

### DIFF
--- a/javascript/workspace.bzl
+++ b/javascript/workspace.bzl
@@ -20,7 +20,7 @@ js_library(
     name = "lib.inner",
     root = ":root",
     deps = {deps},
-    srcs = [":files"],
+    srcs = [":root"],
     visibility = ["//visibility:public"],
 )
 

--- a/npm/workspace.bzl
+++ b/npm/workspace.bzl
@@ -14,7 +14,7 @@ def npm_import_external_rule(plugins):
         )
 
         # packages can have different prefixes
-        mv_result = ctx.execute(["sh", "-c", "mv tmp/* npm"])
+        mv_result = ctx.execute(["sh", "-c", "mv tmp/* npm && rm -fr npm/node_modules"])
         if mv_result.return_code:
             fail("Could not extract package")
 

--- a/typescript/workspace.bzl
+++ b/typescript/workspace.bzl
@@ -22,10 +22,10 @@ load("@better_rules_javascript//typescript:rules.bzl", "ts_export", "ts_import")
 
 ts_import(
     name = "lib.inner",
-    declarations = [":files"],
+    declarations = [":root"],
     deps = {deps},
     root = ":root",
-    js = [":files"],
+    js = [":root"],
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
Caused by duplicative treatment of npm directory

---

This is a weird/hard to explain fix, but it works. Without this, the generated tar has duplicates of the same file. (Doesn't affect anything, except cause warnings and waste cycles.)
