### PR TITLE
Always inline Angular resources regardless of compilation mode

### DIFF
--- a/angular/rules.bzl
+++ b/angular/rules.bzl
@@ -90,46 +90,17 @@ def _angular_library(ctx):
     ts = []
     outputs = []
 
-    # resource
+    # resource — always link files next to output so Angular can resolve templateUrl
 
     for file in ctx.files.resources:
-        if compilation_mode == "opt":
-            inputs.append(
-                link_file(
-                    actions = actions,
-                    file = file,
-                    label = label,
-                    output = output_,
-                ),
-            )
-        else:
-            js_path_ = output_name(
+        inputs.append(
+            link_file(
+                actions = actions,
                 file = file,
                 label = label,
-                prefix = js_prefix,
-                strip_prefix = strip_prefix,
-            )
-            if not file.is_directory:
-                js_path_ = resource_path(js_path_)
-            js_ = actions.declare_file(js_path_)
-            js.append(js_)
-            args = actions.args()
-            args.add(file)
-            args.add(js_)
-            args.set_param_file_format("multiline")
-            args.use_param_file("@%s", use_always = True)
-            actions.run(
-                arguments = [args],
-                executable = compiler.resource_compiler.files_to_run.executable,
-                execution_requirements = {
-                    "requires-worker-protocol": "json",
-                    "supports-workers": "1",
-                },
-                inputs = [file],
-                mnemonic = "TypeScriptTranspile",
-                outputs = [js_],
-                tools = [compiler.resource_compiler.files_to_run],
-            )
+                output = output_,
+            ),
+        )
 
     if compilation_mode != "opt":
         transpile_tsconfig = actions.declare_file("%s/js-tsconfig.json" % ctx.attr.name)


### PR DESCRIPTION
## Summary

In fastbuild mode, Angular resources (HTML templates) were only processed through the resource compiler (HTML → JS module with `exports.content`). The raw HTML files were not linked next to the component output.

This causes Angular 15's TestBed to fail with "Component not resolved: templateUrl" because it can no longer resolve external templates via XHR in jsdom test environments.

This change makes the resource linking path (previously opt-only) run in all compilation modes.

## Impact on other consumers

Safe for all consumers of this repo:
- Consumers using opt mode for tests: no change (already uses this path)
- Consumers using fastbuild for tests: resources are now linked next to output. Existing Angular 14 tests continue to work (verified). Angular 15+ tests get fixed.
- The resource compiler JS modules (`exports.content`) are no longer produced, but no known consumer imports them directly — they exist only as an intermediary for Angular's template resolution.

## TODO

Using `if True:` with a still-present `else:` branch leaves dead code and obscures intent. Since resources should now always be linked, remove the conditional entirely (along with the dead else branch) and inline the `link_file` call directly in the loop.

## Testing

Verified on the `rivet` repo:
- All 15 client unit test targets pass on main (Angular 14) with this change
- Angular 15 branch tests pass with `--compilation_mode=opt` (which uses this same code path)

## Context

Part of the Angular 14 → 15 upgrade in Rivet (RVT-23199).